### PR TITLE
Rollback body if inside an unloaded block & fix for autostep when autostepping in a corner

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,7 @@ export function DefaultOptions() {
  *     fluidDensity: 2.0,
  *     gravity: [0, -10, 0],
  *     minBounceImpulse: .5, // lowest collision impulse that bounces
+ *     isBodyInsideUnloadedBlock: returns a boolean of whether the body is within an unloaded block
  * }
  * ```
  * 

--- a/src/rigidBody.js
+++ b/src/rigidBody.js
@@ -37,6 +37,32 @@ function RigidBody(_aabb, mass, friction, restitution, gravMult, onCollide, auto
     this._sleepFrameCount = 10 | 0
 }
 
+RigidBody.prototype.loadFromCopy = function (loadFrom) {
+    vec3.copy(this.aabb.base, loadFrom.aabb.base)
+    vec3.copy(this.aabb.vec, loadFrom.aabb.vec)
+    vec3.copy(this.aabb.max, loadFrom.aabb.max)
+    this.aabb.mag = loadFrom.aabb.mag
+
+    this.mass = loadFrom.mass
+    this.friction = loadFrom.friction
+    this.restitution = loadFrom.restitution
+    this.gravityMultiplier = loadFrom.gravityMultiplier
+    this.onCollide = loadFrom.onCollide
+    this.autoStep = loadFrom.autoStep
+
+    this.airDrag = loadFrom.airDrag
+    this.fluidDrag = loadFrom.fluidDrag
+    this.onStep = loadFrom.onStep
+
+    vec3.copy(this.velocity, loadFrom.velocity)
+    vec3.copy(this.resting, loadFrom.resting)
+    this.inFluid = loadFrom.inFluid
+    this._ratioInFluid = loadFrom._ratioInFluid
+    vec3.copy(this._forces, loadFrom._forces)
+    vec3.copy(this._impulses, loadFrom._impulses)
+    this._sleepFrameCount = loadFrom._sleepFrameCount
+}
+
 RigidBody.prototype.setPosition = function (p) {
     sanityCheck(p)
     vec3.subtract(p, p, this.aabb.base)


### PR DESCRIPTION
Hi, sorry for this addressing two things at once

Feel free to close this - and potentially address one or both of the issues with your own changes 

The first change: I add the option isBodyInsideUnloadedBlock which rolls back the body to before the changes made by the tick if the body is inside an unloaded block. There's an early out in the main noa tick if the player co-ordinates aren't located in a loaded chunk but this has a few drawbacks:
1. The body will end up 1 physics tick inside the unloaded chunk, and so will end up inside a block if one exists
2. It doesn't check the corners of the player
3. It does nothing for non-player bodies

This logic could have been implemented elsewhere but it felt cleanest here. Unsure how it would be called in noa - personally I'm checking the corners of the body for the local player and just the middle of the base for all other bodies.


The second change is the logic for `bail if no movement happened in the originally blocked direction`

Before the change, if a player walks into a corner and one of the "walls" is one block high and one is more than that, the player won't autostep the "wall" that is one block high. With this change, the player does.